### PR TITLE
fix: Fix build on non-Darwin Clang platforms by restricting -dead_strip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,9 @@ else()
     target_compile_options(pacman PUBLIC -Wall -Wextra -Wsign-compare)
 endif()
 
-# explicitly strip dead code
-if (CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+# explicitly strip dead code (Darwin only)
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin"
+    AND CMAKE_C_COMPILER_ID MATCHES "Clang"
+    AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     target_link_options(pacman PRIVATE LINKER:-dead_strip)
 endif()


### PR DESCRIPTION
The CMake logic previously added -dead_strip whenever Clang was detected, which caused link failures on ELF-based systems (e.g., FreeBSD and Linux) because their linkers do not support this Mach-O–specific flag.

Limit the dead-code stripping option to macOS (Darwin), where the flag is valid and intended.

This restores successful builds on all non-Darwin Clang targets while preserving the original optimization on macOS.